### PR TITLE
Add system theme option and improve theme toggle UX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ const AppRoutes = () => (
 );
 
 const App = () => (
-  <ThemeProvider attribute="class" defaultTheme="system" enableSystem={true}>
+  <ThemeProvider attribute="class" defaultTheme="light" enableSystem={true}>
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
         <TooltipProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ const AppRoutes = () => (
 );
 
 const App = () => (
-  <ThemeProvider attribute="class" defaultTheme="light" enableSystem={true}>
+  <ThemeProvider attribute="class" defaultTheme="system" enableSystem={true}>
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
         <TooltipProvider>

--- a/src/components/admin/ComunicaImport.tsx
+++ b/src/components/admin/ComunicaImport.tsx
@@ -90,14 +90,20 @@ export function ComunicaImport() {
     try {
       const credentials = crmUser && crmPass ? { user: crmUser, pass: crmPass } : undefined;
       const data = await fetchAllCRMContacts(credentials);
-      const filtered = selectedRelTypes.length > 0
-        ? data.filter(c => c.relationship_types.some(rt => selectedRelTypes.includes(rt)))
+      // Matching the rel-type filter + those with NO rel type at all (shown unchecked)
+      const allToShow = selectedRelTypes.length > 0
+        ? data.filter(c => c.relationship_types.some(rt => selectedRelTypes.includes(rt)) || c.relationship_types.length === 0)
         : data;
-      setContacts(filtered);
-      const grouped = groupByLocation(filtered);
+      setContacts(allToShow);
+      const grouped = groupByLocation(allToShow);
       setGroups(grouped);
       setOpenGroups(new Set(grouped.map(g => g.location)));
-      setSelected(new Set(filtered.filter(c => c.etapa?.toLowerCase() !== 'asesora').map(c => c.crm_id)));
+      // Pre-select only those matching the filter (not Asesora, not no-rel-type)
+      const preSelected = allToShow.filter(c =>
+        c.etapa?.toLowerCase() !== 'asesora' &&
+        (selectedRelTypes.length === 0 || c.relationship_types.some(rt => selectedRelTypes.includes(rt))),
+      );
+      setSelected(new Set(preSelected.map(c => c.crm_id)));
       const { data: existing } = await supabase.from('candidates').select('crm_id').eq('round_id', selectedRoundId).not('crm_id', 'is', null);
       setExistingCrmIds(new Set((existing ?? []).map(e => e.crm_id as string)));
       setStep('review');
@@ -123,6 +129,10 @@ export function ComunicaImport() {
 
   const totalFiltered = useMemo(() => filteredGroups.reduce((acc, g) => acc + g.contacts.length, 0), [filteredGroups]);
   const selectedCount = useMemo(() => [...selected].filter(id => contacts.some(c => c.crm_id === id)).length, [selected, contacts]);
+  const noRelTypeCount = useMemo(
+    () => selectedRelTypes.length > 0 ? contacts.filter(c => c.relationship_types.length === 0).length : 0,
+    [contacts, selectedRelTypes],
+  );
 
   function toggleContact(crmId: string) {
     setSelected(prev => { const next = new Set(prev); if (next.has(crmId)) next.delete(crmId); else next.add(crmId); return next; });
@@ -454,6 +464,7 @@ export function ComunicaImport() {
                     <div style={{ fontWeight: 700, fontSize: 13, color: 'var(--avd-fg)' }}>Selecciona los candidatos a importar</div>
                     <div style={{ fontSize: 12, color: 'var(--avd-fg-muted)' }}>
                       {contacts.length} personas · relación <strong>{selectedRelTypes.join(', ') || 'cualquiera'}</strong>
+                      {noRelTypeCount > 0 && <> · <span style={{ color: 'var(--avd-warn-fg)' }}>{noRelTypeCount} sin relación activa (sin marcar)</span></>}
                       {existingCrmIds.size > 0 && <> · <span style={{ color: 'var(--avd-warn-fg)' }}>{existingCrmIds.size} ya en esta votación</span></>}
                     </div>
                   </div>
@@ -523,6 +534,7 @@ export function ComunicaImport() {
                                     {group.contacts.map((c, idx) => {
                                       const alreadyIn = existingCrmIds.has(c.crm_id);
                                       const isSelected = selected.has(c.crm_id);
+                                      const isNoRelType = selectedRelTypes.length > 0 && c.relationship_types.length === 0;
                                       return (
                                         <tr
                                           key={c.crm_id}
@@ -530,7 +542,11 @@ export function ComunicaImport() {
                                           style={{
                                             cursor: 'pointer',
                                             opacity: alreadyIn ? 0.6 : 1,
-                                            background: isSelected ? 'color-mix(in oklch, var(--avd-brand) 6%, transparent)' : (idx % 2 === 0 ? 'transparent' : 'var(--avd-bg-sunken)'),
+                                            background: isSelected
+                                              ? 'color-mix(in oklch, var(--avd-brand) 6%, transparent)'
+                                              : isNoRelType
+                                              ? 'color-mix(in oklch, var(--avd-warn) 10%, transparent)'
+                                              : (idx % 2 === 0 ? 'transparent' : 'var(--avd-bg-sunken)'),
                                             borderBottom: '1px solid var(--avd-border-soft)',
                                           }}
                                         >
@@ -556,6 +572,8 @@ export function ComunicaImport() {
                                               ? c.relationship_types.map(rt => (
                                                 <span key={rt} className="avd-chip" style={{ marginRight: 3, fontSize: 10.5, textTransform: 'capitalize' }}>{rt}</span>
                                               ))
+                                              : isNoRelType
+                                              ? <span className="avd-chip avd-chip-warn" style={{ fontSize: 10.5 }}>sin relación</span>
                                               : <span style={{ color: 'var(--avd-fg-faint)' }}>—</span>
                                             }
                                           </td>

--- a/src/components/shared/ThemeToggle.tsx
+++ b/src/components/shared/ThemeToggle.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { Moon, Sun } from "lucide-react";
+import { Moon, Monitor, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { cn } from "@/lib/utils";
 
@@ -10,27 +10,40 @@ interface ThemeToggleProps {
   buttonClassName?: string;
 }
 
+const NEXT: Record<string, string> = { light: "dark", dark: "system", system: "light" };
+const LABELS: Record<string, string> = {
+  light: "Cambiar a modo oscuro",
+  dark: "Cambiar a modo automático (dispositivo)",
+  system: "Cambiar a modo claro",
+};
+
 export function ThemeToggle({ mode = "floating", className, buttonClassName }: ThemeToggleProps) {
-  const { theme, resolvedTheme, setTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  const activeTheme = useMemo(() => resolvedTheme ?? theme ?? "dark", [resolvedTheme, theme]);
-
   if (!mounted) {
     return null;
   }
 
-  const isDark = activeTheme === "dark";
+  const current = theme ?? "light";
+  const next = NEXT[current] ?? "dark";
+
+  // Icon shows where you'll go on click
+  const icon = current === "light"
+    ? <Moon className="h-5 w-5 transition-transform duration-200 group-hover:-rotate-6" />
+    : current === "dark"
+    ? <Monitor className="h-5 w-5 transition-transform duration-200 group-hover:scale-110" />
+    : <Sun className="h-5 w-5 transition-transform duration-200 group-hover:rotate-6" />;
 
   const toggleButton = (
     <button
       type="button"
-      onClick={() => setTheme(isDark ? "light" : "dark")}
-      aria-label={isDark ? "Cambiar a modo claro" : "Cambiar a modo oscuro"}
+      onClick={() => setTheme(next)}
+      aria-label={LABELS[current] ?? "Cambiar tema"}
       className={cn(
         "group avd-btn",
         mode === "inline"
@@ -40,7 +53,7 @@ export function ThemeToggle({ mode = "floating", className, buttonClassName }: T
       )}
       style={mode === "inline" ? { width: 42, height: 42, flexShrink: 0 } : undefined}
     >
-      {isDark ? <Sun className="h-5 w-5 transition-transform duration-200 group-hover:rotate-6" /> : <Moon className="h-5 w-5 transition-transform duration-200 group-hover:-rotate-6" />}
+      {icon}
     </button>
   );
 
@@ -49,7 +62,7 @@ export function ThemeToggle({ mode = "floating", className, buttonClassName }: T
   }
 
   return createPortal(
-    <div 
+    <div
       className={cn("pointer-events-auto fixed right-4 z-[90] md:right-6", className)}
       style={{ bottom: 'calc(1rem + env(safe-area-inset-bottom))' }}
     >

--- a/src/lib/candidateFormat.ts
+++ b/src/lib/candidateFormat.ts
@@ -1,9 +1,9 @@
-/** Returns only the first surname word (e.g. "García López" → "García") */
+/** Returns the full surname as stored */
 export function formatSurname(surname: string): string {
-  return surname.trim().split(/\s+/)[0] ?? surname;
+  return surname.trim();
 }
 
-/** Returns "Name FirstSurname" for display in all views */
+/** Returns "Name Surname" for display in all views */
 export function formatCandidateName(candidate: { name: string; surname: string }): string {
   return `${candidate.name} ${formatSurname(candidate.surname)}`;
 }

--- a/src/pages/PublicCandidates.tsx
+++ b/src/pages/PublicCandidates.tsx
@@ -187,7 +187,9 @@ export function PublicCandidates() {
     );
   }
 
-  const isDark = theme === "dark";
+  const NEXT_THEME: Record<string, string> = { light: "dark", dark: "system", system: "light" };
+  const currentTheme = theme ?? "light";
+  const nextTheme = NEXT_THEME[currentTheme] ?? "dark";
 
   const currentDetailIndex = detailCandidate ? filtered.findIndex((c) => c.id === detailCandidate.id) : -1;
   const handleNextCandidate = () => {
@@ -254,17 +256,23 @@ export function PublicCandidates() {
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ transition: "transform 0.2s", transform: indexOpen ? "rotate(180deg)" : "none" }}><path d="M6 9l6 6 6-6"/></svg>
             </button>
 
-            {/* Theme toggle */}
+            {/* Theme toggle: light → dark → system → light */}
             {mounted && (
               <button
                 className="avd-btn avd-btn-icon"
-                onClick={() => setTheme(isDark ? "light" : "dark")}
-                title={isDark ? "Cambiar a modo claro" : "Cambiar a modo oscuro"}
+                onClick={() => setTheme(nextTheme)}
+                title={
+                  currentTheme === "light" ? "Cambiar a modo oscuro"
+                  : currentTheme === "dark" ? "Cambiar a modo automático (dispositivo)"
+                  : "Cambiar a modo claro"
+                }
                 style={{ width: 42, height: 42, flexShrink: 0 }}
               >
-                {isDark
-                  ? <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
-                  : <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                {currentTheme === "light"
+                  ? <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                  : currentTheme === "dark"
+                  ? <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+                  : <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
                 }
               </button>
             )}


### PR DESCRIPTION
## Summary
Extended the theme system to support three states (light → dark → system → light) instead of just two, and improved the related UI/UX across multiple components. Also fixed surname formatting to display full names instead of truncating to first surname.

## Key Changes

### Theme Toggle Enhancement
- **ThemeToggle.tsx**: Refactored to support three-state cycling (light → dark → system → light)
  - Removed `useMemo` and `resolvedTheme` dependency
  - Added `NEXT` and `LABELS` lookup tables for theme transitions
  - Updated icon logic to show the destination theme on hover (Moon for dark, Monitor for system, Sun for light)
  - Improved accessibility with context-aware aria-labels

### PublicCandidates Theme Toggle
- Updated theme toggle button to support three-state cycling with appropriate icons and labels
- Added Monitor icon for system theme state
- Improved title text to explain each transition

### ComunicaImport Contact Filtering
- Fixed relationship type filtering to include contacts with NO relationship type when a filter is active
- Separated pre-selection logic: contacts without relationship types are shown but not pre-selected
- Added visual indicator showing count of contacts without active relationships
- Highlighted rows with no relationship type using warning color background
- Added "sin relación" chip badge for contacts without relationship types

### Surname Formatting
- **candidateFormat.ts**: Changed `formatSurname()` to return full surname instead of just the first word
  - Updated JSDoc to reflect the actual behavior
  - This ensures full names are displayed consistently across all views

## Implementation Details
- Theme state now properly cycles through all three options with appropriate visual feedback
- Contact filtering logic now correctly handles the edge case of contacts with empty relationship_types arrays
- UI provides clear visual distinction for contacts without active relationships during import

https://claude.ai/code/session_012PK6isrbXbM6o1iYUnh1Eq