### PR TITLE
Refactor gallery projection logic and enable realtime for seats/candidates

### DIFF
--- a/src/components/admin/voting-detail/ControlsAside.tsx
+++ b/src/components/admin/voting-detail/ControlsAside.tsx
@@ -77,17 +77,17 @@ export function ControlsAside({
                 />
               </div>
             </div>
-            {round.round_finalized && round.show_ballot_summary_projection && round.is_closed && (
+            {round.is_closed && round.round_finalized && (
               <div className="avd-proj-toggle">
                 <div className="avd-label-row">
                   <Sparkles size={14} />
                   <div>
                     <div>Galería final</div>
-                    <div className="avd-sub">{round.show_results_to_voters ? "Visible para votantes" : "Oculta"}</div>
+                    <div className="avd-sub">{round.show_final_gallery_projection ? "Proyectándose" : "Oculta"}</div>
                   </div>
                 </div>
                 <button
-                  className={`avd-switch ${round.show_results_to_voters ? "on" : ""}`}
+                  className={`avd-switch ${round.show_final_gallery_projection ? "on" : ""}`}
                   onClick={toggleGallery}
                 />
               </div>

--- a/src/components/admin/voting-detail/hooks/useRoundActions.ts
+++ b/src/components/admin/voting-detail/hooks/useRoundActions.ts
@@ -125,9 +125,19 @@ export function useRoundActions(opts: Options) {
   const closeVoting = async () => {
     if (!roundId) return;
     setIsCloseRoundConfirmOpen(false);
-    const { error } = await supabase.from("rounds").update({ is_closed: true, is_active: false, is_voting_open: false, join_locked: true, updated_at: new Date().toISOString() }).eq("id", roundId);
+    const { error } = await supabase.from("rounds").update({
+      is_closed: true,
+      is_active: false,
+      is_voting_open: false,
+      join_locked: true,
+      round_finalized: true,
+      show_results_to_voters: false,
+      show_ballot_summary_projection: false,
+      show_final_gallery_projection: false,
+      updated_at: new Date().toISOString(),
+    }).eq("id", roundId);
     if (error) { toast({ title: "Error", description: "No se pudo cerrar la votación", variant: "destructive" }); return; }
-    toast({ title: "Votación cerrada", description: "Se cerró la votación y se bloqueó la entrada" });
+    toast({ title: "Votación cerrada", description: "Activa la galería final cuando quieras mostrarla" });
     await loadRound();
   };
 
@@ -202,8 +212,8 @@ export function useRoundActions(opts: Options) {
   };
 
   const toggleGallery = async () => {
-    if (!roundId || !round?.round_finalized || !round.show_ballot_summary_projection || !round.is_closed) return;
-    const nextOn = !round.show_results_to_voters;
+    if (!roundId || !round?.round_finalized || !round.is_closed) return;
+    const nextOn = !round.show_final_gallery_projection;
     if (nextOn) {
       const { data: activeGalleries } = await supabase
         .from("rounds")
@@ -212,11 +222,17 @@ export function useRoundActions(opts: Options) {
         .neq("id", roundId)
         .limit(1);
       if (activeGalleries && activeGalleries.length > 0) {
-        await supabase.from("rounds").update({ show_results_to_voters: false, show_final_gallery_projection: false, updated_at: new Date().toISOString() }).eq("id", activeGalleries[0].id);
+        await supabase.from("rounds").update({ show_final_gallery_projection: false, updated_at: new Date().toISOString() }).eq("id", activeGalleries[0].id);
         toast({ title: `Galería de "${activeGalleries[0].title}" cerrada`, description: "No puede haber dos galerías activas simultáneamente." });
       }
     }
-    const { error } = await supabase.from("rounds").update({ show_results_to_voters: nextOn, show_final_gallery_projection: nextOn, updated_at: new Date().toISOString() }).eq("id", roundId);
+    const update: Record<string, unknown> = { show_final_gallery_projection: nextOn, updated_at: new Date().toISOString() };
+    if (nextOn) {
+      // When showing the gallery, stop projecting per-round results to avoid stale projection
+      update.show_results_to_voters = false;
+      update.show_ballot_summary_projection = false;
+    }
+    const { error } = await supabase.from("rounds").update(update).eq("id", roundId);
     if (error) { toast({ title: "Error", description: "No se pudo actualizar la galería", variant: "destructive" }); return; }
     toast({ title: nextOn ? "Galería activada" : "Galería desactivada" });
     await loadRound();

--- a/supabase/sqls/015-realtime-seats-candidates.sql
+++ b/supabase/sqls/015-realtime-seats-candidates.sql
@@ -1,0 +1,28 @@
+-- ============================================================================
+-- 015 — Habilitar Realtime para seats y candidates
+-- ============================================================================
+-- El admin y la proyección dependen de eventos en estas tablas para
+-- actualizarse al instante (al unirse a la sala, votar, marcar candidatos…).
+-- ============================================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+     WHERE pubname = 'supabase_realtime' AND tablename = 'seats'
+  ) THEN
+    EXECUTE 'ALTER PUBLICATION supabase_realtime ADD TABLE public.seats';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+     WHERE pubname = 'supabase_realtime' AND tablename = 'candidates'
+  ) THEN
+    EXECUTE 'ALTER PUBLICATION supabase_realtime ADD TABLE public.candidates';
+  END IF;
+END $$;
+
+SELECT tablename
+FROM pg_publication_tables
+WHERE pubname = 'supabase_realtime'
+ORDER BY tablename;


### PR DESCRIPTION
## Summary
This PR refactors the voting round gallery projection feature to use a dedicated `show_final_gallery_projection` field instead of reusing `show_results_to_voters`, and enables Supabase Realtime for the `seats` and `candidates` tables to support real-time updates in the admin interface and projection displays.

## Key Changes

- **Gallery Projection Logic**: 
  - Changed `toggleGallery()` to use `show_final_gallery_projection` instead of `show_results_to_voters` for controlling the final gallery display
  - Updated the condition check to remove the unnecessary `show_ballot_summary_projection` requirement
  - When activating the gallery, now explicitly disables `show_results_to_voters` and `show_ballot_summary_projection` to prevent stale projection data

- **Round Closure**:
  - Extended `closeVoting()` to set `round_finalized: true` and reset all projection-related flags (`show_results_to_voters`, `show_ballot_summary_projection`, `show_final_gallery_projection`) to `false`
  - Updated success toast message to guide users to activate the final gallery when ready

- **UI Updates**:
  - Updated `ControlsAside.tsx` to display the gallery toggle only when round is closed and finalized (simplified condition)
  - Changed the gallery status label from "Visible para votantes" to "Proyectándose" to better reflect the actual state
  - Updated button state binding to use `show_final_gallery_projection` field

- **Database**:
  - Added migration script `015-realtime-seats-candidates.sql` to enable Supabase Realtime publication for `seats` and `candidates` tables, enabling real-time synchronization for admin and projection features

## Implementation Details
The refactoring separates concerns by using dedicated fields for different projection modes rather than overloading `show_results_to_voters`. This prevents conflicts when toggling the final gallery and ensures the projection system displays the correct data at each stage of the voting process.

https://claude.ai/code/session_01W4dKLUdozbC8e6iG8EuF64