### PR TITLE
feat(admin): subida de foto de candidata con arrastrar y soltar

### DIFF
--- a/src/components/admin/voting-detail/CandidatesPane.tsx
+++ b/src/components/admin/voting-detail/CandidatesPane.tsx
@@ -122,7 +122,7 @@ export function CandidatesPane({
                   >
                     <div className="avd-cand-avatar overflow-hidden">
                       {c.image_url
-                        ? <img src={c.image_url} alt="" className="w-full h-full object-cover rounded-full" onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; (e.currentTarget.parentElement!).dataset.initials = initials(c); (e.currentTarget.parentElement!).textContent = initials(c); }} />
+                        ? <img src={c.image_url} alt="" loading="lazy" decoding="async" className="w-full h-full object-cover rounded-full" onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; (e.currentTarget.parentElement!).dataset.initials = initials(c); (e.currentTarget.parentElement!).textContent = initials(c); }} />
                         : initials(c)}
                     </div>
                     <div className="avd-cand-info">
@@ -187,7 +187,7 @@ export function CandidatesPane({
                       <div className="avd-cand-card-head">
                         <div className="avd-cand-card-avatar overflow-hidden">
                           {c.image_url
-                            ? <img src={c.image_url} alt="" className="w-full h-full object-cover" onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; e.currentTarget.parentElement!.textContent = initials(c); }} />
+                            ? <img src={c.image_url} alt="" loading="lazy" decoding="async" className="w-full h-full object-cover" onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; e.currentTarget.parentElement!.textContent = initials(c); }} />
                             : initials(c)}
                         </div>
                         <div className="avd-cand-card-body">

--- a/src/components/admin/voting-detail/dialogs/CandidateFormDialog.tsx
+++ b/src/components/admin/voting-detail/dialogs/CandidateFormDialog.tsx
@@ -1,7 +1,87 @@
-import { XCircle } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ImagePlus, XCircle, X } from "lucide-react";
 import { formatCandidateName } from "@/lib/candidateFormat";
+import { isImageFile, MAX_IMAGE_INPUT_BYTES } from "@/lib/candidateImage";
 import type { Candidate } from "../hooks/useRoundDetail";
 import type { CandidateFormState } from "../hooks/useCandidateActions";
+
+interface ImageDropFieldProps {
+  imageUrl: string;
+  imageFile: File | null;
+  setImageFile: (f: File | null) => void;
+  clearImageUrl: () => void;
+}
+
+function ImageDropField({ imageUrl, imageFile, setImageFile, clearImageUrl }: ImageDropFieldProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [fileError, setFileError] = useState<string | null>(null);
+
+  const previewUrl = useMemo(() => (imageFile ? URL.createObjectURL(imageFile) : null), [imageFile]);
+  useEffect(() => () => { if (previewUrl) URL.revokeObjectURL(previewUrl); }, [previewUrl]);
+  const shownImage = previewUrl || imageUrl || null;
+
+  const handleFiles = (files: FileList | null) => {
+    const file = files?.[0];
+    if (!file) return;
+    if (!isImageFile(file)) { setFileError("Solo se admiten archivos de imagen."); return; }
+    if (file.size > MAX_IMAGE_INPUT_BYTES) { setFileError("La imagen es demasiado grande (máx. 15 MB)."); return; }
+    setFileError(null);
+    setImageFile(file);
+  };
+
+  const removeImage = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setFileError(null);
+    setImageFile(null);
+    clearImageUrl();
+  };
+
+  return (
+    <div className="avd-form-field">
+      <label className="avd-label">Fotografía</label>
+      <div
+        className={`avd-imgdrop ${dragOver ? "avd-imgdrop-over" : ""}`}
+        role="button"
+        tabIndex={0}
+        onClick={() => fileInputRef.current?.click()}
+        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); fileInputRef.current?.click(); } }}
+        onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={(e) => { e.preventDefault(); setDragOver(false); handleFiles(e.dataTransfer.files); }}
+      >
+        {shownImage ? (
+          <>
+            <img src={shownImage} alt="Foto de la candidata" className="avd-imgdrop-preview" loading="lazy" decoding="async" />
+            <div className="avd-imgdrop-text">
+              <strong>{imageFile ? imageFile.name : "Foto actual"}</strong>
+              Arrastra otra imagen o pulsa para cambiarla.
+            </div>
+            <button type="button" className="avd-btn avd-btn-ghost avd-btn-icon-sm avd-imgdrop-remove" onClick={removeImage} title="Quitar imagen">
+              <X size={13} />
+            </button>
+          </>
+        ) : (
+          <>
+            <ImagePlus size={20} />
+            <div className="avd-imgdrop-text">
+              <strong>Arrastra una imagen aquí</strong>
+              o pulsa para adjuntarla desde tu dispositivo.
+            </div>
+          </>
+        )}
+      </div>
+      {fileError && <p className="avd-imgdrop-error">{fileError}</p>}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={(e) => { handleFiles(e.target.files); e.target.value = ""; }}
+      />
+    </div>
+  );
+}
 
 interface FormDialogProps {
   open: boolean;
@@ -10,11 +90,14 @@ interface FormDialogProps {
   description: string;
   candidateForm: CandidateFormState;
   setCandidateForm: React.Dispatch<React.SetStateAction<CandidateFormState>>;
+  imageFile: File | null;
+  setImageFile: (f: File | null) => void;
+  saving: boolean;
   onSave: () => void;
   saveLabel: string;
 }
 
-function FormDialog({ open, setOpen, title, description, candidateForm, setCandidateForm, onSave, saveLabel }: FormDialogProps) {
+function FormDialog({ open, setOpen, title, description, candidateForm, setCandidateForm, imageFile, setImageFile, saving, onSave, saveLabel }: FormDialogProps) {
   if (!open) return null;
   return (
     <div className="avd-dialog-overlay" onMouseDown={(e) => { if (e.target === e.currentTarget) setOpen(false); }}>
@@ -54,11 +137,17 @@ function FormDialog({ open, setOpen, title, description, candidateForm, setCandi
               <label className="avd-label">Descripción</label>
               <textarea className="avd-textarea" value={candidateForm.description} onChange={(e) => setCandidateForm((p) => ({ ...p, description: e.target.value }))} />
             </div>
+            <ImageDropField
+              imageUrl={candidateForm.image_url}
+              imageFile={imageFile}
+              setImageFile={setImageFile}
+              clearImageUrl={() => setCandidateForm((p) => ({ ...p, image_url: "" }))}
+            />
           </div>
         </div>
         <div className="avd-dialog-foot">
-          <button className="avd-btn avd-btn-sm" onClick={() => setOpen(false)}>Cancelar</button>
-          <button className="avd-btn avd-btn-sm avd-btn-primary" onClick={onSave}>{saveLabel}</button>
+          <button className="avd-btn avd-btn-sm" onClick={() => setOpen(false)} disabled={saving}>Cancelar</button>
+          <button className="avd-btn avd-btn-sm avd-btn-primary" onClick={onSave} disabled={saving}>{saving ? "Guardando..." : saveLabel}</button>
         </div>
       </div>
     </div>
@@ -72,6 +161,9 @@ interface Props {
   setIsEditCandidateOpen: (v: boolean) => void;
   candidateForm: CandidateFormState;
   setCandidateForm: React.Dispatch<React.SetStateAction<CandidateFormState>>;
+  candidateImageFile: File | null;
+  setCandidateImageFile: (f: File | null) => void;
+  savingCandidate: boolean;
   addCandidate: () => void;
   updateCandidate: () => void;
   candidateToSelect: Candidate | null;
@@ -96,6 +188,9 @@ export function CandidateFormDialog(props: Props) {
         description="Completa los datos principales. Podrás editar después."
         candidateForm={props.candidateForm}
         setCandidateForm={props.setCandidateForm}
+        imageFile={props.candidateImageFile}
+        setImageFile={props.setCandidateImageFile}
+        saving={props.savingCandidate}
         onSave={props.addCandidate}
         saveLabel="Guardar candidata"
       />
@@ -108,6 +203,9 @@ export function CandidateFormDialog(props: Props) {
         description="Actualiza los datos de la candidata seleccionada."
         candidateForm={props.candidateForm}
         setCandidateForm={props.setCandidateForm}
+        imageFile={props.candidateImageFile}
+        setImageFile={props.setCandidateImageFile}
+        saving={props.savingCandidate}
         onSave={props.updateCandidate}
         saveLabel="Guardar cambios"
       />

--- a/src/components/admin/voting-detail/hooks/useCandidateActions.ts
+++ b/src/components/admin/voting-detail/hooks/useCandidateActions.ts
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
 import { errorLog } from "@/lib/logger";
+import { uploadCandidateImage, removeCandidateImage } from "@/lib/candidateImage";
 import type { useToast } from "@/hooks/use-toast";
 import type { RoundDetail, Candidate } from "./useRoundDetail";
 
@@ -29,6 +30,8 @@ interface UseCandidateActionsOptions {
 export function useCandidateActions({ roundId, round, candidates, loadRound, toast }: UseCandidateActionsOptions) {
   const [editingCandidate, setEditingCandidate] = useState<Candidate | null>(null);
   const [candidateForm, setCandidateForm] = useState<CandidateFormState>(EMPTY_FORM);
+  const [candidateImageFile, setCandidateImageFile] = useState<File | null>(null);
+  const [savingCandidate, setSavingCandidate] = useState(false);
   const [isAddCandidateOpen, setIsAddCandidateOpen] = useState(false);
   const [isEditCandidateOpen, setIsEditCandidateOpen] = useState(false);
   const [isImportOpen, setIsImportOpen] = useState(false);
@@ -38,56 +41,93 @@ export function useCandidateActions({ roundId, round, candidates, loadRound, toa
   const [importingFile, setImportingFile] = useState(false);
   const [forceSelectingId, setForceSelectingId] = useState<string | null>(null);
 
-  const resetCandidateForm = () => setCandidateForm(EMPTY_FORM);
+  const resetCandidateForm = () => { setCandidateForm(EMPTY_FORM); setCandidateImageFile(null); };
 
   const openAddCandidateDialog = () => { setEditingCandidate(null); resetCandidateForm(); setIsAddCandidateOpen(true); };
 
   const openEditCandidateDialog = (candidate: Candidate) => {
     setEditingCandidate(candidate);
     setCandidateForm({ name: candidate.name, surname: candidate.surname, location: candidate.location || "", group_name: candidate.group_name || "", age: candidate.age || "", description: candidate.description || "", image_url: candidate.image_url || "" });
+    setCandidateImageFile(null);
     setIsEditCandidateOpen(true);
   };
 
   const addCandidate = async () => {
-    if (!round) return;
+    if (!round || savingCandidate) return;
     if (!candidateForm.name.trim() || !candidateForm.surname.trim()) {
       toast({ title: "Campos obligatorios", description: "El nombre y apellido son obligatorios", variant: "destructive" });
       return;
     }
-    const maxOrderIndex = Math.max(0, ...candidates.map((c) => c.order_index || 0));
-    const { error } = await supabase.from("candidates").insert([{
-      round_id: round.id, name: candidateForm.name.trim(), surname: candidateForm.surname.trim(),
-      location: candidateForm.location.trim() || null, group_name: candidateForm.group_name.trim() || null,
-      age: typeof candidateForm.age === "number" ? candidateForm.age : null,
-      description: candidateForm.description.trim() || null, image_url: candidateForm.image_url.trim() || null,
-      order_index: maxOrderIndex + 1,
-    }]);
-    if (error) { toast({ title: "Error", description: "No se pudo añadir el candidato", variant: "destructive" }); return; }
-    toast({ title: "Candidato añadido" });
-    setIsAddCandidateOpen(false);
-    resetCandidateForm();
-    await loadRound();
+    setSavingCandidate(true);
+    try {
+      let imageUrl = candidateForm.image_url.trim() || null;
+      if (candidateImageFile) {
+        try {
+          imageUrl = await uploadCandidateImage(candidateImageFile, round.id);
+        } catch (e) {
+          errorLog(e);
+          toast({ title: "Error", description: "No se pudo subir la imagen", variant: "destructive" });
+          return;
+        }
+      }
+      const maxOrderIndex = Math.max(0, ...candidates.map((c) => c.order_index || 0));
+      const { error } = await supabase.from("candidates").insert([{
+        round_id: round.id, name: candidateForm.name.trim(), surname: candidateForm.surname.trim(),
+        location: candidateForm.location.trim() || null, group_name: candidateForm.group_name.trim() || null,
+        age: typeof candidateForm.age === "number" ? candidateForm.age : null,
+        description: candidateForm.description.trim() || null, image_url: imageUrl,
+        order_index: maxOrderIndex + 1,
+      }]);
+      if (error) {
+        if (candidateImageFile && imageUrl) await removeCandidateImage(imageUrl);
+        toast({ title: "Error", description: "No se pudo añadir el candidato", variant: "destructive" });
+        return;
+      }
+      toast({ title: "Candidato añadido" });
+      setIsAddCandidateOpen(false);
+      resetCandidateForm();
+      await loadRound();
+    } finally { setSavingCandidate(false); }
   };
 
   const updateCandidate = async () => {
-    if (!editingCandidate) return;
+    if (!editingCandidate || savingCandidate) return;
     if (!candidateForm.name.trim() || !candidateForm.surname.trim()) {
       toast({ title: "Campos obligatorios", description: "El nombre y apellido son obligatorios", variant: "destructive" });
       return;
     }
-    const { error } = await supabase.from("candidates").update({
-      name: candidateForm.name.trim(), surname: candidateForm.surname.trim(),
-      location: candidateForm.location.trim() || null, group_name: candidateForm.group_name.trim() || null,
-      age: typeof candidateForm.age === "number" ? candidateForm.age : null,
-      description: candidateForm.description.trim() || null, image_url: candidateForm.image_url.trim() || null,
-      updated_at: new Date().toISOString(),
-    }).eq("id", editingCandidate.id);
-    if (error) { toast({ title: "Error", description: "No se pudo editar el candidato", variant: "destructive" }); return; }
-    toast({ title: "Candidato actualizado" });
-    setIsEditCandidateOpen(false);
-    setEditingCandidate(null);
-    resetCandidateForm();
-    await loadRound();
+    setSavingCandidate(true);
+    try {
+      const previousImageUrl = editingCandidate.image_url;
+      let imageUrl = candidateForm.image_url.trim() || null;
+      if (candidateImageFile && roundId) {
+        try {
+          imageUrl = await uploadCandidateImage(candidateImageFile, roundId);
+        } catch (e) {
+          errorLog(e);
+          toast({ title: "Error", description: "No se pudo subir la imagen", variant: "destructive" });
+          return;
+        }
+      }
+      const { error } = await supabase.from("candidates").update({
+        name: candidateForm.name.trim(), surname: candidateForm.surname.trim(),
+        location: candidateForm.location.trim() || null, group_name: candidateForm.group_name.trim() || null,
+        age: typeof candidateForm.age === "number" ? candidateForm.age : null,
+        description: candidateForm.description.trim() || null, image_url: imageUrl,
+        updated_at: new Date().toISOString(),
+      }).eq("id", editingCandidate.id);
+      if (error) {
+        if (candidateImageFile && imageUrl) await removeCandidateImage(imageUrl);
+        toast({ title: "Error", description: "No se pudo editar el candidato", variant: "destructive" });
+        return;
+      }
+      if (previousImageUrl && previousImageUrl !== imageUrl) await removeCandidateImage(previousImageUrl);
+      toast({ title: "Candidato actualizado" });
+      setIsEditCandidateOpen(false);
+      setEditingCandidate(null);
+      resetCandidateForm();
+      await loadRound();
+    } finally { setSavingCandidate(false); }
   };
 
   const unselectCandidate = async (candidateId: string) => {
@@ -207,6 +247,8 @@ export function useCandidateActions({ roundId, round, candidates, loadRound, toa
   return {
     editingCandidate, setEditingCandidate,
     candidateForm, setCandidateForm,
+    candidateImageFile, setCandidateImageFile,
+    savingCandidate,
     isAddCandidateOpen, setIsAddCandidateOpen,
     isEditCandidateOpen, setIsEditCandidateOpen,
     isImportOpen, setIsImportOpen,

--- a/src/components/admin/voting-detail/index.tsx
+++ b/src/components/admin/voting-detail/index.tsx
@@ -46,6 +46,8 @@ export function AdminVotingDetail() {
   /* Candidate CRUD state + actions */
   const {
     candidateForm, setCandidateForm,
+    candidateImageFile, setCandidateImageFile,
+    savingCandidate,
     isAddCandidateOpen, setIsAddCandidateOpen,
     isEditCandidateOpen, setIsEditCandidateOpen,
     isImportOpen, setIsImportOpen,
@@ -387,6 +389,8 @@ export function AdminVotingDetail() {
         isAddCandidateOpen={isAddCandidateOpen} setIsAddCandidateOpen={setIsAddCandidateOpen}
         isEditCandidateOpen={isEditCandidateOpen} setIsEditCandidateOpen={setIsEditCandidateOpen}
         candidateForm={candidateForm} setCandidateForm={setCandidateForm}
+        candidateImageFile={candidateImageFile} setCandidateImageFile={setCandidateImageFile}
+        savingCandidate={savingCandidate}
         addCandidate={addCandidate} updateCandidate={updateCandidate}
         candidateToSelect={candidateToSelect} setCandidateToSelect={setCandidateToSelect}
         quickSelectCandidate={quickSelectCandidate}

--- a/src/index.css
+++ b/src/index.css
@@ -1379,6 +1379,40 @@
 .avd-form-grid-2 { grid-template-columns: 1fr 1fr; }
 .avd-form-field { display: flex; flex-direction: column; gap: 5px; }
 
+/* ── Image drop zone (candidate photo) ── */
+.avd-imgdrop {
+  position: relative;
+  display: flex; align-items: center; gap: 12px;
+  min-height: 72px;
+  padding: 12px 14px;
+  border: 1.5px dashed var(--avd-border);
+  border-radius: var(--avd-radius-sm);
+  background: var(--avd-bg-sunken);
+  color: var(--avd-fg-muted);
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.avd-imgdrop:hover { border-color: color-mix(in oklch, var(--avd-brand) 45%, var(--avd-border)); }
+.avd-imgdrop.avd-imgdrop-over {
+  border-color: var(--avd-brand);
+  background: color-mix(in oklch, var(--avd-brand) 8%, var(--avd-bg-sunken));
+}
+.avd-imgdrop svg { flex-shrink: 0; color: var(--avd-fg-faint); }
+.avd-imgdrop-preview {
+  width: 52px; height: 52px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  border: 1px solid var(--avd-border);
+  background: var(--avd-bg-elev);
+}
+.avd-imgdrop-text { font-size: 12.5px; line-height: 1.4; min-width: 0; overflow-wrap: anywhere; padding-right: 24px; }
+.avd-imgdrop-text strong { display: block; color: var(--avd-fg); font-weight: 600; }
+.avd-imgdrop-remove { position: absolute; top: 6px; right: 6px; }
+.avd-imgdrop-error { font-size: 11.5px; color: var(--avd-bad); margin-top: 2px; }
+.dark .avd-imgdrop { background: var(--avd-n-1000); }
+.dark .avd-imgdrop.avd-imgdrop-over { background: color-mix(in oklch, var(--avd-brand) 12%, var(--avd-n-1000)); }
+
 /* ── Dialog overlay ── */
 .avd-dialog-overlay {
   position: fixed; inset: 0;

--- a/src/lib/candidateImage.ts
+++ b/src/lib/candidateImage.ts
@@ -1,0 +1,70 @@
+import { supabase } from "@/lib/supabase";
+import { errorLog } from "@/lib/logger";
+
+const BUCKET = "candidate-photos";
+const MAX_DIMENSION = 900;
+const JPEG_QUALITY = 0.85;
+
+/** Máximo aceptado antes de comprimir (fotos de móvil pueden ser enormes). */
+export const MAX_IMAGE_INPUT_BYTES = 15 * 1024 * 1024;
+
+export function isImageFile(file: File): boolean {
+  return file.type.startsWith("image/");
+}
+
+/**
+ * Reduce la imagen a un máximo de 900px y la recomprime a JPEG para que
+ * las listas de candidatas no carguen fotos de varios MB.
+ * Si el navegador no puede decodificar el formato, devuelve el archivo original.
+ */
+async function compressImage(file: File): Promise<{ blob: Blob; contentType: string; ext: string }> {
+  try {
+    const bitmap = await createImageBitmap(file);
+    const scale = Math.min(1, MAX_DIMENSION / Math.max(bitmap.width, bitmap.height));
+    const width = Math.max(1, Math.round(bitmap.width * scale));
+    const height = Math.max(1, Math.round(bitmap.height * scale));
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("canvas 2d no disponible");
+    ctx.drawImage(bitmap, 0, 0, width, height);
+    bitmap.close();
+    const blob = await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((b) => (b ? resolve(b) : reject(new Error("toBlob falló"))), "image/jpeg", JPEG_QUALITY);
+    });
+    return { blob, contentType: "image/jpeg", ext: "jpg" };
+  } catch (e) {
+    errorLog(e);
+    const ext = file.name.split(".").pop()?.toLowerCase() || "jpg";
+    return { blob: file, contentType: file.type || "image/jpeg", ext };
+  }
+}
+
+/** Sube la foto al bucket y devuelve la URL pública. Lanza si falla la subida. */
+export async function uploadCandidateImage(file: File, roundId: string): Promise<string> {
+  const { blob, contentType, ext } = await compressImage(file);
+  const path = `${roundId}/${crypto.randomUUID()}.${ext}`;
+  const { error } = await supabase.storage.from(BUCKET).upload(path, blob, {
+    contentType,
+    cacheControl: "31536000",
+    upsert: false,
+  });
+  if (error) throw error;
+  return supabase.storage.from(BUCKET).getPublicUrl(path).data.publicUrl;
+}
+
+/**
+ * Borra del Storage una foto por su URL pública. Ignora URLs externas y la
+ * carpeta `shared/` (fotos del CRM reutilizadas entre rondas). Nunca lanza.
+ */
+export async function removeCandidateImage(imageUrl: string | null | undefined): Promise<void> {
+  if (!imageUrl || !imageUrl.includes(`${BUCKET}/`)) return;
+  const path = decodeURIComponent(imageUrl.split(`${BUCKET}/`)[1] || "").split("?")[0];
+  if (!path || path.startsWith("shared/")) return;
+  try {
+    await supabase.storage.from(BUCKET).remove([path]);
+  } catch (e) {
+    errorLog(e);
+  }
+}

--- a/supabase/migrations/20260715120000_candidate_photos_upload_policies.sql
+++ b/supabase/migrations/20260715120000_candidate_photos_upload_policies.sql
@@ -1,0 +1,47 @@
+-- =============================================================================
+-- Migration: candidate_photos_upload_policies
+-- Author:    Claude
+-- Date:      2026-07-15
+-- Issue/PR:  N/A
+-- Purpose:   Permitir subir fotos de candidatas desde el panel de admin
+--            (drag & drop / adjuntar). El cliente usa la anon key, así que el
+--            bucket candidate-photos necesita policies de INSERT/UPDATE/DELETE
+--            además del SELECT público ya existente.
+--
+-- Rules:
+--   * Idempotent: CREATE ... IF NOT EXISTS, CREATE OR REPLACE, DO $$ EXCEPTION ...
+--   * Transactional: BEGIN ... COMMIT (except DDL that disallows it).
+--   * No data deletes without explicit user approval and explanation here.
+--   * Apply via MCP `apply_migration` (auto-inserts version into schema_migrations).
+--   * Never edit this file after it has been applied — write a new migration.
+-- =============================================================================
+
+BEGIN;
+
+-- Bucket público de lectura (ya existe en prod; esto lo garantiza en entornos nuevos)
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('candidate-photos', 'candidate-photos', true)
+ON CONFLICT (id) DO UPDATE SET public = true;
+
+DO $$ BEGIN
+  CREATE POLICY "candidate_photos_select" ON storage.objects
+    FOR SELECT USING (bucket_id = 'candidate-photos');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE POLICY "candidate_photos_insert" ON storage.objects
+    FOR INSERT WITH CHECK (bucket_id = 'candidate-photos');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE POLICY "candidate_photos_update" ON storage.objects
+    FOR UPDATE USING (bucket_id = 'candidate-photos')
+    WITH CHECK (bucket_id = 'candidate-photos');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE POLICY "candidate_photos_delete" ON storage.objects
+    FOR DELETE USING (bucket_id = 'candidate-photos');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+COMMIT;


### PR DESCRIPTION
- Zona de imagen en el diálogo de añadir/editar candidata: drag & drop,
  adjuntar desde el dispositivo, previsualización y quitar foto.
- Compresión en cliente (máx. 900px, JPEG) antes de subir al bucket
  candidate-photos; al reemplazar o quitar se borra la foto anterior
  (excepto shared/ del CRM).
- Carga lazy de las fotos en la lista y tarjetas del admin.
- Migración con policies de INSERT/UPDATE/DELETE del bucket para la anon key.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C3pzDDMhyduBtnKnUG8KSi